### PR TITLE
Remove unused import of GeneralizedGenerated.jl

### DIFF
--- a/src/arraylib.jl
+++ b/src/arraylib.jl
@@ -1,7 +1,5 @@
 # map
 
-using GeneralizedGenerated
-
 function idxs(sym, T)
     ((Symbol(sym, i) for i=1:ndims(T))...,)
 end


### PR DESCRIPTION
Since GeneralizedGenerated.jl is not in Project.toml, loading DaggerArrays.jl produces an error from its `using GeneralizedGenerated`. As it looks like it's not used anymore, how about removing the import?